### PR TITLE
Refactor client routing and character views

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,26 +1,31 @@
+rules_version = '2';
 service cloud.firestore {
-match /databases/{database}/documents {
-function isSignedIn() { return request.auth != null; }
-function isOwner(uid) { return isSignedIn() && request.auth.uid == uid; }
+  match /databases/{database}/documents {
 
+    match /chars/{charId} {
+      allow read: if true;
+      allow create: if request.auth != null
+        && request.resource.data.owner_uid == request.auth.uid;
+      allow update, delete: if request.auth != null
+        && request.auth.uid == resource.data.owner_uid;
+    }
 
-match /chars/{charId} {
-allow read: if true; // 공개 프로필(필요 시 제한)
-allow create: if isSignedIn() && request.resource.data.owner_uid == request.auth.uid;
-allow update, delete: if isOwner(resource.data.owner_uid);
-}
+    match /char_items/{docId} {
+      allow read: if true;
+      allow write: if request.auth != null;
+    }
 
+    match /items/{itemId} {
+      allow read: if true;
+      allow write: if false; // 전역 마스터는 수동 관리
+    }
 
-match /encounters/{encId} {
-allow read: if true;
-allow create: if isSignedIn(); // 서버 타임스탬프 검증 권장
-allow update, delete: if isOwner(resource.data.created_by);
-}
+    match /encounters/{encId} {
+      allow read, write: if request.auth != null;
+    }
 
-
-match /profiles/{uid} {
-allow read: if true;
-allow write: if isOwner(uid);
-}
-}
+    match /relations/{docId} {
+      allow read, write: if request.auth != null;
+    }
+  }
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -75,3 +75,42 @@ body{margin:0;background:var(--bg);color:var(--text);font:14px/1.5 system-ui, -a
 .site-list { display:flex; flex-direction:column; gap:8px; }
 .site-item { border:1px solid #223; border-radius:12px; padding:10px; cursor:pointer; }
 .site-item.sel { outline:2px solid #2f6df6; }
+/* === ToH additions === */
+.container.narrow { max-width: 720px; margin: 0 auto; padding: 16px; }
+.card { background:#1b1e23; border:1px solid #2a2f36; border-radius:14px; }
+.p0{padding:0} .p12{padding:12px} .p16{padding:16px}
+.mt6{margin-top:6px} .mt8{margin-top:8px} .mt12{margin-top:12px} .mt16{margin-top:16px}
+.row{display:flex;gap:12px;align-items:center}
+.col{display:flex;flex-direction:column}
+.center{display:flex;justify-content:center;align-items:center}
+.title{font-weight:600}
+.text-dim{opacity:.7}
+.btn{padding:10px 14px;border-radius:10px;border:1px solid #39414b;background:#2a3140}
+.btn.primary{background:#4062ff;border-color:#4062ff} .btn.large{padding:12px 18px;font-weight:600}
+.btn.ghost{background:transparent;border-color:#39414b}
+.icon-btn{border:1px solid #39414b;background:#2a3140;padding:6px 10px;border-radius:10px}
+.icon-btn.heart{border-radius:50%}
+.input,.textarea{width:100%;border-radius:10px;border:1px solid #39414b;background:#0f1216;color:#ddd;padding:10px}
+.chips{display:flex;gap:8px;flex-wrap:wrap}
+.chip{padding:6px 10px;border-radius:999px;border:1px solid #39414b;background:#151922}
+.chip.active{background:#4062ff;border-color:#4062ff}
+.thumb.sq{width:64px;height:64px;border-radius:12px;background:#101318}
+.avatar-wrap{position:relative;width:144px;height:144px;border-radius:16px;overflow:hidden}
+.avatar-wrap img{width:100%;height:100%;object-fit:cover}
+.avatar-wrap img.noimg{background:#0f1216}
+.stats4{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin-top:12px}
+.pill{display:inline-flex;gap:6px;align-items:center;padding:6px 10px;border-radius:10px;background:#141922;border:1px solid #2b313a}
+.pill.white .v{color:#fff}
+.pill.pink .v{color:#ff69b4}
+.pill.gold .v{color:#ffd166}
+.pill.red .v{color:#ff6b6b}
+.actions .btn{min-width:140px}
+.tabbar{display:flex;gap:8px;border-bottom:1px solid #2a2f36;padding:8px}
+.tab{padding:8px 12px;border:0;background:transparent;border-bottom:2px solid transparent}
+.tab.active{border-color:#4062ff}
+.subtabs{display:flex;gap:8px;border-bottom:1px dashed #2a2f36;padding:8px 16px}
+.sub{padding:6px 10px;border:0;background:transparent;border-bottom:2px solid transparent}
+.sub.active{border-color:#4062ff}
+.grid2{display:grid;grid-template-columns:1fr 1fr;gap:8px}
+.grid3{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}
+.skill input{margin-right:8px}

--- a/public/js/api/ai.js
+++ b/public/js/api/ai.js
@@ -1,0 +1,85 @@
+// /public/js/api/ai.js
+// BYOK: localStorage('toh_byok') 에 저장된 Gemini API 키 사용 (절대 서버에 저장하지 않음)
+const GEM_ENDPOINT = 'https://generativelanguage.googleapis.com/v1beta';
+
+function getKey(){
+  return localStorage.getItem('toh_byok') || '';
+}
+
+export function setByok(k){
+  localStorage.setItem('toh_byok', (k||'').trim());
+}
+
+// 공통 호출
+async function callGemini(model, systemText, userText){
+  const key = getKey();
+  if(!key) throw new Error('Gemini API Key(BYOK)가 필요해.');
+  const url = `${GEM_ENDPOINT}/models/${model}:generateContent?key=${encodeURIComponent(key)}`;
+  const body = {
+    contents: [{ role:"user", parts:[{text: (systemText?(`[SYSTEM]\n${systemText}\n\n`):'') + userText }] }],
+    generationConfig: { temperature: 0.9 }
+  };
+  const res = await fetch(url, { method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body) });
+  if(!res.ok){ const t = await res.text(); throw new Error(`Gemini 호출 실패: ${res.status} ${t}`); }
+  const json = await res.json();
+  const out = json?.candidates?.[0]?.content?.parts?.[0]?.text || '';
+  return out;
+}
+
+// 저가 스케치(3안) → 내부 랜덤 1안 채택
+export async function genSketch({worldDetailSites, participants, items, relationNote}){
+  const sys = `너는 TRPG 조우 스케치러. JSON만 출력해.
+- 장소는 입력된 sites 중에서 하나를 id로 선택해야 한다.
+- 3안 생성 후 내부 랜덤으로 하나를 고를 것이므로, 각 안의 톤/디테일은 살짝씩 달라야 한다.
+- 출력 스키마:
+{ "options":[
+  {"where":{"world_id":"...","site_id":"...","why":"..."},
+   "what":["...","...","...","..."],
+   "result_hint":{"verdict":["win","loss","draw","mutual"],"gains":["..."],"losses":["..."]}},
+  ...
+] }`;
+  const usr = `sites(JSON): ${JSON.stringify(worldDetailSites).slice(0,4000)}
+participants(desc_soft): ${JSON.stringify(participants).slice(0,2000)}
+items(simple): ${JSON.stringify(items||[])}
+relation_note(optional): ${relationNote||''}`;
+  const text = await callGemini('gemini-1.5-flash', sys, usr);
+  return text;
+}
+
+// 고가 정제(최종 서사)
+export async function refineNarrative({sketchOne, worldIntro}){
+  const sys = `너는 서사 편집자. 아래 스케치를 짧고 선명한 최종 서사로 다듬어라.
+- 어디서/왜: 2문장
+- 무슨 일이 있었나: 4~8문장 (스킬/아이템 "등장 타이밍"만 콕 집어)
+- 결과: verdict, gains[], losses[]를 JSON으로 첨부
+- 출력 포맷:
+{ "where":"...", "what":"...", "result":{"verdict":"win|loss|draw|mutual","gains":[],"losses":[]} }`;
+  const usr = `world_intro: ${worldIntro}
+sketch_selected: ${JSON.stringify(sketchOne).slice(0,4000)}`;
+  const text = await callGemini('gemini-1.5-pro', sys, usr);
+  return text;
+}
+
+// 스킬 리롤(4개) — desc_raw + desc_soft 동시 생성
+export async function rerollSkills({name, worldName, info}){
+  const sys = `캐릭터의 능력 4개를 제안해라.
+제약:
+- 각 능력 이름 ≤ 20자
+- 각 설명 desc_raw ≤ 100자, 4문장 이하
+- desc_soft(완곡화)는 절대어를 피해서 "대부분/흔히/짧게" 같은 톤으로 누그러뜨린 버전
+출력:
+{"abilities":[{"name":"","desc_raw":"","desc_soft":""}, ... (x4)]}`;
+  const usr = `name:${name}\nworld:${worldName}\ninfo(≤500자):${info}`;
+  const text = await callGemini('gemini-1.5-flash', sys, usr);
+  return text;
+}
+
+// 에피소드(본문+요약) — 요약은 리롤용으로만 별도 호출 가능
+export async function genEpisode({seedNote, povName}){
+  const sys = `개인 관점 에피소드를 작성.
+제약: 본문 ≤ 500자, 25문장 이하. 이후 한 줄 요약도 생성.
+출력: {"episode":"...", "summary":"..."}`;
+  const usr = `seed:${seedNote||''}\npov:${povName||''}`;
+  const text = await callGemini('gemini-1.5-pro', sys, usr);
+  return text;
+}

--- a/public/js/api/firebase.js
+++ b/public/js/api/firebase.js
@@ -1,41 +1,34 @@
-// Firebase SDK v10+ modular
+// /public/js/api/firebase.js  (전체 교체)
+
+// --- Firebase SDK v10+ modular ---
 import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js';
 import {
   getAuth, GoogleAuthProvider, onAuthStateChanged, signInWithPopup, signOut
 } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
 import {
-  getFirestore, collection, doc, setDoc, getDoc, addDoc, updateDoc, getDocs,
-  query, where, orderBy, limit, serverTimestamp, runTransaction, increment
+  getFirestore, doc, getDoc, setDoc, addDoc, updateDoc,
+  collection, query, where, getDocs, orderBy, limit, serverTimestamp
 } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js';
 import {
-  getStorage, ref, uploadBytes, getDownloadURL, updateMetadata
+  getStorage, ref, uploadBytes, getDownloadURL
 } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-storage.js';
 
-
-// ✅ Firebase 프로젝트 설정
+// !! 여기에 네 프로젝트 설정값 유지 !!
 const firebaseConfig = {
   apiKey: "AIzaSyA4ilV6tRpqZrkgXRTKdFP_YjAl3CmfYWo",
   authDomain: "tale-of-heros---fangame.firebaseapp.com",
   projectId: "tale-of-heros---fangame",
-  storageBucket: "tale-of-heros---fangame.appspot.com", // 꼭 appspot.com 형식
+  storageBucket: "tale-of-heros---fangame.firebasestorage.app",
   messagingSenderId: "648588906865",
   appId: "1:648588906865:web:eb4baf1c0ed9cdbc7ba6d0"
 };
 
 export const app = initializeApp(firebaseConfig);
-
-// Auth
 export const auth = getAuth(app);
 export const provider = new GoogleAuthProvider();
-export const ax = { onAuthStateChanged, signInWithPopup, signOut };
-
-// Firestore
 export const db = getFirestore(app);
-export const fx = {
-  collection, doc, setDoc, getDoc, addDoc, updateDoc, getDocs,
-  query, where, orderBy, limit, serverTimestamp, runTransaction, increment
-};
-
-// Storage
 export const storage = getStorage(app);
-export const sx = { ref, uploadBytes, getDownloadURL, updateMetadata };
+
+export const fx = { doc, getDoc, setDoc, addDoc, updateDoc, collection, query, where, getDocs, orderBy, limit, serverTimestamp };
+export const sx = { ref, uploadBytes, getDownloadURL };
+export const ax = { onAuthStateChanged, signInWithPopup, signOut };

--- a/public/js/api/store.js
+++ b/public/js/api/store.js
@@ -1,216 +1,106 @@
-// store.js
-import { db, fx } from './firebase.js';
+// /public/js/api/store.js  (전체 교체)
+import { db, auth, fx, storage, sx } from './firebase.js';
 import { showToast } from '../ui/toast.js';
 
-const KEY = {
-  chars: 'toh_chars',
-  worlds: 'toh_worlds',
-  enc: 'toh_enc',
-  settings: 'toh_settings',
-  weekly: 'toh_weekly',
-  rankings: 'toh_rankings'
-};
-
-// ★ App은 한 번만!
 export const App = {
-  // 화면에서 쓰는 상태는 여기에 통일
   state: {
     user: null,
     worlds: null,
-    chars: [],
-    enc: [],
-    settings: { byok: '' },
-  },
-  currentWorldId: 'gionkir',
-  user: null,         // onAuthChanged에서 채움(편의상 루트도 유지)
-  rankings: null      // 랭킹 캐시
+    currentWorldId: 'gionkir',
+    myChars: [],        // 항상 서버→메모리
+  }
 };
 
-// -------------------- 로컬 캐시 --------------------
+// ----- 유틸 -----
+export function tierOf(elo=1000){
+  if (elo < 900) return {name:'Bronze',  color:'#7a5a3a'};
+  if (elo < 1100) return {name:'Silver',  color:'#8aa0b8'};
+  if (elo < 1300) return {name:'Gold',    color:'#d1a43f'};
+  if (elo < 1500) return {name:'Platinum',color:'#69c0c6'};
+  if (elo < 1700) return {name:'Diamond', color:'#7ec2ff'};
+  return {name:'Master', color:'#b678ff'};
+}
 
-export async function initLocalCache() {
-  // worlds 로컬 없으면 assets/worlds.json 로드
-  let w = null;
-  try { w = JSON.parse(localStorage.getItem(KEY.worlds) || 'null'); } catch {}
-  if (!w) {
-    w = await fetch('/assets/worlds.json').then(r => r.json());
-    localStorage.setItem(KEY.worlds, JSON.stringify(w));
-  }
+export async function fetchWorlds(){
+  if (App.state.worlds) return App.state.worlds;
+  const w = await fetch('/assets/worlds.json').then(r=>r.json());
   App.state.worlds = w;
-
-  // 나머지 로컬 우선
-  try { App.state.chars = JSON.parse(localStorage.getItem(KEY.chars) || '[]'); } catch { App.state.chars = []; }
-  try { App.state.enc   = JSON.parse(localStorage.getItem(KEY.enc)   || '[]'); } catch { App.state.enc = []; }
-  try { App.state.settings = JSON.parse(localStorage.getItem(KEY.settings) || '{"byok":""}'); } catch { App.state.settings = { byok: '' }; }
-
-  // 씨드가 필요하면(선택) — seedDemo가 없으면 건너뜀
-  if (!App.state.chars.length && typeof window.seedDemo === 'function') {
-    window.seedDemo(); // 너가 만든 함수가 있을 때만 호출
-  }
+  return w;
 }
 
-export function saveLocal() {
-  localStorage.setItem(KEY.chars, JSON.stringify(App.state.chars));
-  localStorage.setItem(KEY.enc, JSON.stringify(App.state.enc));
-  localStorage.setItem(KEY.settings, JSON.stringify(App.state.settings));
+// ----- Auth 후크 밖에서 호출하는 “읽기/쓰기” 래퍼 -----
+export async function fetchMyChars(uid){
+  const q = fx.query(fx.collection(db,'chars'), fx.where('owner_uid','==', uid));
+  const s = await fx.getDocs(q);
+  const arr = [];
+  s.forEach(d => arr.push({ id: d.id, ...d.data() }));
+  App.state.myChars = arr;
+  return arr;
 }
 
-export function exportAll() {
-  const blob = new Blob(
-    [JSON.stringify({ chars: App.state.chars, enc: App.state.enc, worlds: App.state.worlds }, null, 2)],
-    { type: 'application/json' }
-  );
-  const a = document.createElement('a');
-  a.href = URL.createObjectURL(blob);
-  a.download = 'toh-export.json';
-  a.click();
-  URL.revokeObjectURL(a.href);
-}
-
-export function importAll(e) {
-  const f = e.target.files?.[0]; if (!f) return;
-  const r = new FileReader();
-  r.onload = () => {
-    try {
-      const data = JSON.parse(r.result);
-      if (data.worlds) { App.state.worlds = data.worlds; localStorage.setItem(KEY.worlds, JSON.stringify(data.worlds)); }
-      if (data.chars)  { App.state.chars  = data.chars;  saveLocal(); }
-      if (data.enc)    { App.state.enc    = data.enc;    saveLocal(); }
-      showToast('불러오기 완료'); location.hash = '#/home';
-    } catch {
-      showToast('불러오기 실패');
-    }
-  };
-  r.readAsText(f);
-}
-
-export function setWorldChip() {
-  const el = document.getElementById('worldChip');
-  if (!el) return;
-  const w = App.state.worlds?.worlds?.find(x => x.id === App.currentWorldId);
-  el.textContent = '세계관: ' + (w?.name || '-');
-}
-
-export function ensureWeeklyReset() {
-  const KSTMonday00 = lastWeeklyResetKST();
-  const mark = +(localStorage.getItem(KEY.weekly) || 0);
-  if (mark < KSTMonday00) {
-    App.state.chars.forEach(c => c.likes_weekly = 0);
-    saveLocal();
-    localStorage.setItem(KEY.weekly, KSTMonday00);
-  }
-}
-
-function lastWeeklyResetKST() {
-  const d = new Date();
-  const utc = d.getTime() + d.getTimezoneOffset() * 60000;
-  const kst = new Date(utc + 9 * 3600 * 1000);
-  kst.setHours(0, 0, 0, 0);
-  const dow = kst.getDay(); // 0=Sun
-  const need = 1; // Mon
-  const diff = (dow >= need ? dow - need : 7 - (need - dow));
-  kst.setDate(kst.getDate() - diff);
-  // 다시 로컬 epoch로
-  const back = kst.getTime() - 9 * 3600 * 1000 - d.getTimezoneOffset() * 60000;
-  return back;
-}
-
-
-// ---------- 랭킹: Firestore에서 읽기 ----------
-export async function loadRankingsFromServer(topN = 50){
-  const col  = fx.collection(db, 'chars');
-  const take = (field)=> fx.getDocs(fx.query(col, fx.orderBy(field,'desc'), fx.limit(topN)));
-  const [w,t,e] = await Promise.all([ take('likes_weekly'), take('likes_total'), take('elo') ]);
-
-  const toArr = (snap)=>{ const arr=[]; snap.forEach(d=> arr.push({ id:d.id, ...d.data() })); return arr; };
-  App.rankings = { weekly: toArr(w), total: toArr(t), elo: toArr(e), fetchedAt: Date.now() };
-  try { localStorage.setItem(KEY.rankings, JSON.stringify(App.rankings)); } catch {}
-  return App.rankings;
-}
-export function restoreRankingCache(){
-  try{ const raw = localStorage.getItem(KEY.rankings); if(raw) App.rankings = JSON.parse(raw); }catch{}
-}
-
-
-// ---------- 좋아요 (7일 쿨타임) ----------
-const RELIKE_MS = 7 * 24 * 60 * 60 * 1000;
-
-export async function likeCharacter(charId, currentUser){
-  if(!currentUser){ showToast && showToast('로그인이 필요해'); return; }
-  const uid = currentUser.uid;
-
-  // 내 좋아요 기록
-  const likeDocRef = fx.doc(db, 'chars', charId, 'likes', uid);
-  const likeDoc    = await fx.getDoc(likeDocRef);
+export async function createCharMinimal({ world_id, name, input_info }){
+  const u = auth.currentUser;
+  if(!u) throw new Error('로그인이 필요해');
   const now = Date.now();
-  if (likeDoc.exists()){
-    const last = likeDoc.data().lastLikedAt?.toMillis?.() ?? likeDoc.data().lastLikedAt ?? 0;
-    const remain = last + RELIKE_MS - now;
-    if (remain > 0){
-      const days = Math.ceil(remain / (24*60*60*1000));
-      showToast && showToast(`아직 ${days}일 남았어. 일주일 후에 다시 가능해!`);
-      return;
-    }
-  }
-
-  // 기록 갱신
-  await fx.setDoc(likeDocRef, { uid, lastLikedAt: fx.serverTimestamp() }, { merge:true });
-
-  // 캐릭 카운트 +1 (규칙에서 +1만 허용)
-  const charRef = fx.doc(db, 'chars', charId);
-  await fx.setDoc(charRef, {
-    likes_total:  fx.increment(1),
-    likes_weekly: fx.increment(1)
-  }, { merge:true });
-
-  // 로컬 반영(있으면)
-  const i = App.state.chars.findIndex(c=> (c.char_id||c.id) === charId);
-  if(i>=0){
-    const c = App.state.chars[i];
-    c.likes_total  = (c.likes_total  || 0) + 1;
-    c.likes_weekly = (c.likes_weekly || 0) + 1;
-    saveLocal();
-  }
-  showToast && showToast('좋아요! 💙');
-
-  // (선택) 랭킹 새로고침
-  try { await loadRankingsFromServer(); } catch {}
+  const docRef = await fx.addDoc(fx.collection(db,'chars'), {
+    owner_uid: u.uid,
+    world_id, name, input_info,
+    image_url: '',
+    abilities_all: [
+      {name:'',desc_raw:'',desc_soft:''},
+      {name:'',desc_raw:'',desc_soft:''},
+      {name:'',desc_raw:'',desc_soft:''},
+      {name:'',desc_raw:'',desc_soft:''}
+    ],
+    abilities_equipped: [0,1],
+    items_equipped: [],
+    narrative: '',
+    summary: '',
+    summary_line: '',
+    elo: 1000, wins:0, losses:0, draws:0,
+    likes_total:0, likes_weekly:0,
+    battle_count:0, explore_count:0,
+    createdAt: now, updatedAt: now
+  });
+  showToast('캐릭터가 생성되었어!');
+  return docRef.id;
 }
 
-// ---------- Elo 업데이트(두 캐릭 동시에) ----------
-function expectedScore(rA, rB){ return 1 / (1 + Math.pow(10, (rB - rA) / 400)); }
+export async function updateAbilitiesEquipped(charId, indices){
+  const u = auth.currentUser; if(!u) return;
+  if(!Array.isArray(indices) || indices.length !== 2) return;
+  await fx.updateDoc(fx.doc(db,'chars',charId), { abilities_equipped: indices, updatedAt: Date.now() });
+  showToast('스킬 장착 변경');
+}
 
-export async function applyBattleResult(charAId, charBId, verdict, K=32){
-  const aRef = fx.doc(db, 'chars', charAId);
-  const bRef = fx.doc(db, 'chars', charBId);
+export async function updateItemsEquipped(charId, charItemDocIds /* length ≤3 */){
+  const u = auth.currentUser; if(!u) return;
+  const safe = (charItemDocIds||[]).slice(0,3);
+  await fx.updateDoc(fx.doc(db,'chars',charId), { items_equipped: safe, updatedAt: Date.now() });
+  showToast('아이템 장착 변경');
+}
 
-  await fx.runTransaction(db, async (tx)=>{
-    const aSnap = await tx.get(aRef);
-    const bSnap = await tx.get(bRef);
-    if(!aSnap.exists() || !bSnap.exists()) throw new Error('캐릭터 없음');
+// ----- 이미지 1:1 업로드(512x512 중앙 크롭) -----
+export async function uploadAvatarSquare(charId, file){
+  const u = auth.currentUser;
+  if(!u) throw new Error('로그인이 필요해');
+  const bmp = await createImageBitmap(await file.arrayBuffer().then(b=>new Blob([b])));
+  const size = Math.min(bmp.width, bmp.height);
+  const sx0 = (bmp.width  - size)/2;
+  const sy0 = (bmp.height - size)/2;
 
-    const A = aSnap.data(), B = bSnap.data();
-    const RA = A.elo ?? 1200, RB = B.elo ?? 1200;
+  const canvas = document.createElement('canvas');
+  canvas.width = 512; canvas.height = 512;
+  const ctx = canvas.getContext('2d');
+  ctx.imageSmoothingEnabled = true;
+  ctx.drawImage(bmp, sx0, sy0, size, size, 0, 0, 512, 512);
 
-    let SA = 0.5, SB = 0.5;
-    if (verdict==='win')  { SA=1; SB=0; }
-    if (verdict==='loss') { SA=0; SB=1; }
-
-    const EA = expectedScore(RA, RB), EB = expectedScore(RB, RA);
-    const newRA = Math.round(RA + K * (SA - EA));
-    const newRB = Math.round(RB + K * (SB - EB));
-
-    tx.set(aRef, {
-      elo:newRA,
-      wins:(A.wins||0)+(verdict==='win'?1:0),
-      losses:(A.losses||0)+(verdict==='loss'?1:0),
-      draws:(A.draws||0)+(verdict==='draw'?1:0)
-    },{merge:true});
-    tx.set(bRef, {
-      elo:newRB,
-      wins:(B.wins||0)+(verdict==='loss'?1:0),
-      losses:(B.losses||0)+(verdict==='win'?1:0),
-      draws:(B.draws||0)+(verdict==='draw'?1:0)
-    },{merge:true});
-  });
+  const blob = await new Promise(res => canvas.toBlob(res, 'image/jpeg', 0.85));
+  const path = `char_avatars/${u.uid}/${charId}/v${Date.now()}.jpg`;
+  const r = sx.ref(storage, path);
+  await sx.uploadBytes(r, blob, { contentType: 'image/jpeg', cacheControl: 'public,max-age=31536000,immutable' });
+  const url = await sx.getDownloadURL(r);
+  await fx.updateDoc(fx.doc(db,'chars',charId), { image_url: url, updatedAt: Date.now() });
+  showToast('아바타 업로드 완료');
+  return url;
 }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,22 +1,9 @@
 import { router, highlightTab } from './router.js';
 import { onAuthChanged, signInWithGoogle, signOutNow } from './api/auth.js';
-import { ensureWeeklyReset, initLocalCache, setWorldChip } from './api/store.js';
-
-import './tabs/home.js';
-import './tabs/adventure.js';
-import './tabs/rankings.js';
-import './tabs/friends.js';
-import './tabs/me.js';
-import './tabs/relations.js';
-import './tabs/char.js';   // ← 따옴표와 세미콜론 필수!
 
 window.addEventListener('hashchange', ()=>{ highlightTab(); router(); });
 
 async function boot(){
-  await initLocalCache();
-  ensureWeeklyReset();
-
-  // 버튼이 없을 수도 있으니 null 보호
   const btnLogin = document.getElementById('btnLogin');
   const btnLogout = document.getElementById('btnLogout');
   if (btnLogin)  btnLogin.onclick  = signInWithGoogle;
@@ -27,7 +14,6 @@ async function boot(){
     if (btnLogout) btnLogout.style.display = user ? 'inline-block' : 'none';
   });
 
-  setWorldChip();
   highlightTab();
   router();
 }

--- a/public/js/router.js
+++ b/public/js/router.js
@@ -1,15 +1,22 @@
+import { showHome } from './tabs/home.js';
+import { showCharDetail } from './tabs/char.js';
+import { showCreate } from './tabs/create.js';
+
 export function highlightTab(){
-const hash = location.hash || '#/home';
-const tab = hash.split('/')[1];
-document.querySelectorAll('.bottombar a').forEach(a=>{
-a.classList.toggle('active', a.dataset.tab===tab);
-});
+  const hash = location.hash || '#/home';
+  const tab = hash.split('/')[1];
+  document.querySelectorAll('.bottombar a').forEach(a=>{
+    a.classList.toggle('active', a.dataset.tab===tab);
+  });
 }
 
-
 export function router(){
-const hash = location.hash || '#/home';
-const [_, path, id] = hash.split('/');
-const event = new CustomEvent('route', { detail: { path, id } });
-window.dispatchEvent(event);
+  const hash = location.hash || '#/home';
+  if(hash.startsWith('#/char/')){
+    showCharDetail();
+  }else if(hash === '#/create'){
+    showCreate();
+  }else{
+    showHome();
+  }
 }

--- a/public/js/tabs/char.js
+++ b/public/js/tabs/char.js
@@ -1,107 +1,195 @@
-// public/js/tabs/char.js
-import { App, saveLocal, likeCharacter } from '../api/store.js';
-import { el } from '../ui/components.js';
-import { storage, sx } from '../api/firebase.js';
-import { auth } from '../api/auth.js';
+// /public/js/tabs/char.js
+import { db, auth, fx } from '../api/firebase.js';
+import { App, tierOf, uploadAvatarSquare, updateAbilitiesEquipped, updateItemsEquipped } from '../api/store.js';
 import { showToast } from '../ui/toast.js';
 
-function makeFileInput(onChange){
-  const input = el('input', {
-    type:'file',
-    accept:'image/*',
-    capture:'environment',
-    style:'display:none'
-  });
-  input.onchange = onChange;
-  document.body.appendChild(input);
-  return input;
+function parseId(){
+  const hash = location.hash || '';
+  const m = hash.match(/^#\/char\/(.+)$/);
+  return m ? m[1] : null;
 }
 
-async function handleUpload(c){
-  const picker = makeFileInput(async (e)=>{
-    const f = e.target.files && e.target.files[0];
-    if(!f) return;
+export async function showCharDetail(){
+  const id = parseId();
+  if(!id){ document.getElementById('view').innerHTML='<p>잘못된 경로</p>'; return; }
+  const doc = await fx.getDoc(fx.doc(db,'chars',id));
+  if(!doc.exists()){ document.getElementById('view').innerHTML='<p>캐릭터가 없네</p>'; return; }
+  const c = { id: doc.id, ...doc.data() };
+  render(c);
+}
 
-    const uid = (auth && auth.currentUser && auth.currentUser.uid) || 'anon';
-    const safe = `${Date.now()}_${(f.name||'img').replace(/[^a-zA-Z0-9._-]/g,'_')}`;
-    const r = sx.ref(storage, `uploads/${uid}/${c.char_id || c.id}/${safe}`);
+function rateText(w,l){ const t=w+l; if(!t) return '0%'; return Math.round(w*100/t)+'%'; }
 
-    await sx.uploadBytes(r, f, {
-      contentType: f.type || 'image/jpeg',
-      cacheControl: 'public, max-age=31536000, immutable'
+async function handleUpload(id){
+  const input = document.createElement('input');
+  input.type='file'; input.accept='image/*';
+  input.onchange = async ()=>{
+    const f = input.files?.[0]; if(!f) return;
+    await uploadAvatarSquare(id, f);
+    location.reload();
+  };
+  input.click();
+}
+
+async function fetchInventory(charId){
+  const q = fx.query(fx.collection(db,'char_items'), fx.where('char_id','==', `chars/${charId}`));
+  const s = await fx.getDocs(q);
+  const arr=[]; s.forEach(d=>arr.push({id:d.id, ...d.data()}));
+  return arr;
+}
+
+function render(c){
+  const root = document.getElementById('view');
+  const tier = tierOf(c.elo);
+  const isOwner = auth.currentUser && c.owner_uid === auth.currentUser.uid;
+
+  root.innerHTML = `
+  <section class="container narrow">
+    <div class="char-top card p16">
+      <div class="avatar-wrap" style="border:3px solid ${tier.color}">
+        <img src="${c.image_url||''}" alt="" onerror="this.src=''; this.classList.add('noimg')" />
+        ${isOwner? `<button id="btnUpload" class="icon-btn">업로드</button>`:''}
+      </div>
+      <div class="meta">
+        <h3 class="name">${c.name}</h3>
+        <div class="chips"><span class="chip">${c.world_id}</span></div>
+        <div class="like-area"><button class="icon-btn heart" id="btnLike">♥</button></div>
+      </div>
+
+      <div class="stats4">
+        <div class="stat pill white"><div class="k">승률</div><div class="v">${rateText(c.wins,c.losses)}</div></div>
+        <div class="stat pill pink"><div class="k">누적 좋아요</div><div class="v">${c.likes_total||0}</div></div>
+        <div class="stat pill gold"><div class="k">Elo</div><div class="v">${c.elo||1000}</div></div>
+        <div class="stat pill red"><div class="k">주간 좋아요</div><div class="v">${c.likes_weekly||0}</div></div>
+      </div>
+      <div class="counts mt6 text-dim">전투 ${c.battle_count||0} · 탐험 ${c.explore_count||0}</div>
+
+      <div class="actions center mt16">
+        <button class="btn large" id="btnBattle">배틀 시작</button>
+        <button class="btn large ghost" id="btnEncounter">조우 시작</button>
+      </div>
+    </div>
+
+    <div class="tabs card p0 mt16">
+      <div class="tabbar">
+        <button class="tab active" data-t="bio">서사/에피소드/관계</button>
+        <button class="tab" data-t="loadout">스킬/아이템</button>
+        <button class="tab" data-t="history">전적</button>
+      </div>
+      <div class="tabview" id="tabview"></div>
+    </div>
+  </section>
+  `;
+
+  // 버튼
+  if(isOwner){ root.querySelector('#btnUpload')?.addEventListener('click', ()=>handleUpload(c.id)); }
+
+  // 좋아요(추후 구현)
+  root.querySelector('#btnLike').onclick = ()=> showToast('좋아요는 나중에!');
+
+  // 탭
+  const view = root.querySelector('#tabview');
+  const tabs = root.querySelectorAll('.tabbar .tab');
+  tabs.forEach(b=>b.onclick = ()=>{ tabs.forEach(x=>x.classList.remove('active')); b.classList.add('active'); renderTab(b.dataset.t, c, view); });
+  renderTab('bio', c, view);
+
+  root.querySelector('#btnBattle').onclick   = ()=> showToast('매칭 로직은 다음 패치에서!');
+  root.querySelector('#btnEncounter').onclick= ()=> showToast('조우 매칭도 다음 패치에서!');
+}
+
+function renderTab(which, c, view){
+  if(which==='bio'){
+    view.innerHTML = `
+      <div class="subtabs">
+        <button class="sub active" data-s="narr">서사</button>
+        <button class="sub" data-s="epis">미니 에피소드</button>
+        <button class="sub" data-s="rel">관계</button>
+      </div>
+      <div id="subview" class="p16"></div>
+    `;
+    const sv = view.querySelector('#subview');
+    const subs = view.querySelectorAll('.subtabs .sub');
+    subs.forEach(b=>b.onclick=()=>{ subs.forEach(x=>x.classList.remove('active')); b.classList.add('active'); renderSub(b.dataset.s,c,sv); });
+    renderSub('narr',c,sv);
+  }
+  if(which==='loadout'){
+    renderLoadout(c, view);
+  }
+  if(which==='history'){
+    view.innerHTML = `<div class="p16">전적은 곧 들어가!</div>`;
+  }
+}
+
+function renderSub(s, c, sv){
+  if(s==='narr'){
+    sv.innerHTML = `
+      <div class="mb8 text-dim">한줄 요약</div>
+      <div class="card p12">${c.summary_line||'-'}</div>
+      <div class="mb8 mt16 text-dim">기본 소개</div>
+      <div class="card p12">${c.summary||'-'}</div>
+      <div class="mb8 mt16 text-dim">탄생 배경</div>
+      <div class="card p12">${c.narrative||'-'}</div>
+    `;
+  } else if(s==='epis'){
+    sv.innerHTML = `<div class="text-dim">미니 에피소드는 나중에 리스트로!</div>`;
+  } else if(s==='rel'){
+    sv.innerHTML = `<div class="text-dim">관계 메모는 배틀 후 10분 내 생성 · 양측 삭제 가능 (UI 추후)</div>`;
+  }
+}
+
+async function renderLoadout(c, view){
+  const isOwner = auth.currentUser && c.owner_uid === auth.currentUser.uid;
+  // 스킬(4개 중 2개)
+  let html = `
+    <div class="p16">
+      <h4>스킬 (4개 중 2개 선택)</h4>
+      <div class="grid2 mt8">
+        ${c.abilities_all.map((ab,i)=>`
+          <label class="card p12 skill">
+            <input type="checkbox" data-i="${i}" ${c.abilities_equipped?.includes(i)?'checked':''} ${!isOwner?'disabled':''}/>
+            <div class="name">${ab?.name||`능력 ${i+1}`}</div>
+            <div class="desc">${ab?.desc_soft||'-'}</div>
+          </label>`).join('')}
+      </div>
+    </div>
+  `;
+
+  // 아이템 장착 3칸 (인벤토리 간단 표기)
+  html += `
+    <div class="p16">
+      <h4 class="mt12">아이템 장착 (최대 3개)</h4>
+      <div id="itemsBox" class="grid3 mt8"></div>
+      ${isOwner? `<button id="btnEquip" class="btn mt8">인벤토리에서 선택</button>`:''}
+    </div>
+  `;
+
+  view.innerHTML = html;
+
+  // 스킬 체크: 2개 제한
+  const boxes = Array.from(view.querySelectorAll('.skill input[type=checkbox]'));
+  boxes.forEach(b=>{
+    b.onchange = ()=>{
+      const on = boxes.filter(x=>x.checked).map(x=>+x.dataset.i);
+      if(on.length>2){ b.checked=false; return showToast('스킬은 2개까지만!'); }
+      if(isOwner && on.length===2) updateAbilitiesEquipped(c.id, on);
+    };
+  });
+
+  // 아이템 3칸 표시(간단)
+  const inv = await fetchInventory(c.id);
+  const box = view.querySelector('#itemsBox');
+  const equipped = c.items_equipped||[];
+  box.innerHTML = [0,1,2].map(slot=>{
+    const docId = equipped[slot];
+    const label = docId ? (inv.find(i=>i.id===docId)?.item_id || '아이템') : '(비어 있음)';
+    return `<div class="card p12">${label}</div>`;
+  }).join('');
+
+  if(isOwner){
+    view.querySelector('#btnEquip')?.addEventListener('click', ()=>{
+      // 간단 토글: 앞 3개를 장착 예시 (실서비스에선 피커 UI)
+      const selected = inv.slice(0,3).map(x=>x.id);
+      updateItemsEquipped(c.id, selected);
     });
-    const url = await sx.getDownloadURL(r);
-
-    c.image_url = url;
-    saveLocal();
-    showToast && showToast('이미지 업로드 완료');
-    render(c.char_id || c.id);
-    picker.remove();
-  });
-  picker.click();
-}
-
-function render(charId){
-  const v = document.getElementById('view');
-  if(!v) return;
-
-  const c = App.state.chars.find(x => (x.char_id || x.id) === charId);
-  if(!c){
-    v.textContent = '캐릭터를 찾을 수 없어.';
-    return;
   }
-
-  const img = c.image_url
-    ? el('img', { src:c.image_url, style:'width:100%;max-height:240px;object-fit:cover;border-radius:12px;border:1px solid #212a36' })
-    : el('div',{ className:'card', style:'height:180px;display:flex;align-items:center;justify-content:center;color:#9aa4b2' }, '이미지 없음');
-
-  const info = el('div',{ className:'card' },
-    el('div',{ className:'title' }, c.name),
-    el('div',{ className:'muted' }, `세계관: ${c.world_id || '-'}`),
-    el('div',{},
-      el('span',{ className:'pill' }, '주간 ' + (c.likes_weekly || 0)),
-      el('span',{ className:'pill' }, '누적 ' + (c.likes_total  || 0)),
-      el('span',{ className:'pill' }, 'Elo '   + (c.elo          || 0))
-    ),
-    el('div',{ className:'hr' }),
-    el('div',{},
-      el('div',{ className:'muted' }, '소개'),
-      el('div',{}, c.summary || '(요약 없음)')
-    ),
-    el('div',{ className:'hr' }),
-    el('div',{},
-      el('div',{ className:'muted' }, '능력'),
-      ...((c.abilities || []).map(a =>
-        el('div',{ className:'row' },
-          el('span',{ className:'pill' }, a.name),
-          el('div',{}, a.desc || a.desc_raw || '')
-        )
-      ))
-    )
-  );
-
-  const btnUpload = el('button',{ className:'btn pri', onclick:()=>handleUpload(c) },
-    c.image_url ? '이미지 변경' : '이미지 업로드'
-  );
-
-  const btnLike = el('button',{ className:'btn',
-    onclick:()=> likeCharacter(c.char_id || c.id, auth.currentUser)
-  }, '좋아요');
-
-  const btnBack = el('button',{ className:'btn', onclick:()=>history.back() }, '← 돌아가기');
-
-  v.replaceChildren(
-    el('div',{ className:'col', style:'gap:12px' },
-      img,
-      el('div',{ className:'row', style:'gap:8px' }, btnUpload, btnLike),
-      info,
-      el('div',{}, btnBack)
-    )
-  );
 }
-
-window.addEventListener('route', (e)=>{
-  if(e.detail && e.detail.path === 'char' && e.detail.id){
-    render(e.detail.id);
-  }
-});

--- a/public/js/tabs/create.js
+++ b/public/js/tabs/create.js
@@ -1,0 +1,50 @@
+// /public/js/tabs/create.js
+import { fetchWorlds, createCharMinimal, App } from '../api/store.js';
+import { showToast } from '../ui/toast.js';
+
+export async function showCreate(){
+  const root = document.getElementById('view');
+  const worlds = await fetchWorlds();
+  const worldList = (worlds?.worlds||[]);
+
+  root.innerHTML = `
+  <section class="container narrow">
+    <h2>새 캐릭터 만들기</h2>
+    <div class="card p16">
+      <label class="lbl">세계관</label>
+      <div class="chips" id="wchips">
+        ${worldList.map(w=>`<button class="chip" data-w="${w.id}">${w.name}</button>`).join('')}
+      </div>
+
+      <label class="lbl">이름 (≤20자)</label>
+      <input id="cname" maxlength="20" class="input" placeholder="이름" />
+
+      <label class="lbl">설명 (≤500자)</label>
+      <textarea id="cinfo" maxlength="500" class="textarea" rows="6" placeholder="캐릭터 소개/설정"></textarea>
+
+      <button id="saveBtn" class="btn primary mt16">저장</button>
+    </div>
+  </section>
+  `;
+
+  let world_id = worldList[0]?.id || 'gionkir';
+  const chips = root.querySelectorAll('#wchips .chip');
+  chips.forEach(b=>{
+    if(b.dataset.w === world_id) b.classList.add('active');
+    b.onclick = ()=>{
+      chips.forEach(x=>x.classList.remove('active'));
+      b.classList.add('active');
+      world_id = b.dataset.w;
+    };
+  });
+
+  root.querySelector('#saveBtn').onclick = async ()=>{
+    const name = root.querySelector('#cname').value.trim();
+    const info = root.querySelector('#cinfo').value.trim();
+    if(!name) return showToast('이름을 입력해줘');
+    try{
+      const id = await createCharMinimal({ world_id, name, input_info: info });
+      location.hash = `#/char/${id}`;
+    }catch(e){ showToast('생성 실패: '+e.message); }
+  };
+}

--- a/public/js/tabs/home.js
+++ b/public/js/tabs/home.js
@@ -1,45 +1,38 @@
-import { App } from '../api/store.js';
-import { el } from '../ui/components.js';
+// /public/js/tabs/home.js  (목록 렌더 부분만 교체)
+// myChars 를 세로 카드로 렌더하고, 클릭 시 #/char/:id 로 이동.
 
-function charCard(c){
-  const open = () => location.hash = `#/char/${c.char_id || c.id}`;
-  const thumb = c.image_url
-    ? el('img',{ className:'char-thumb', src:c.image_url, alt:c.name })
-    : el('div',{ className:'char-thumb blank' }, '이미지 없음');
+import { App, fetchMyChars } from '../api/store.js';
+import { auth } from '../api/firebase.js';
 
-  return el('div',{ className:'card char', onclick:open, style:'cursor:pointer' },
-    thumb,
-    el('div',{},
-      el('div',{ className:'title' }, c.name),
-      el('div',{ className:'muted' }, `세계관: ${c.world_id || '-'}`),
-      el('div',{ className:'meta' },
-        el('span',{ className:'pill' }, `주간 ${c.likes_weekly||0}`),
-        el('span',{ className:'pill' }, `누적 ${c.likes_total||0}`),
-        el('span',{ className:'pill' }, `Elo ${c.elo||0}`)
-      )
-    )
-  );
+export async function showHome(){
+  const root = document.getElementById('view');
+  const u = auth.currentUser;
+  if(!u){ root.innerHTML = `<section class="container narrow"><p>로그인하면 캐릭터를 볼 수 있어.</p></section>`; return; }
+
+  const list = await fetchMyChars(u.uid);
+  root.innerHTML = `
+    <section class="container narrow">
+      ${list.map(c=>`
+        <div class="card row clickable" data-id="${c.id}">
+          <div class="thumb sq"></div>
+          <div class="col">
+            <div class="title">${c.name}</div>
+            <div class="chips"><span class="chip">${c.world_id}</span></div>
+            <div class="row gap8 mt6">
+              <span class="pill">주간 ${c.likes_weekly||0}</span>
+              <span class="pill">누적 ${c.likes_total||0}</span>
+              <span class="pill">Elo ${c.elo||1000}</span>
+            </div>
+          </div>
+        </div>
+      `).join('')}
+      <div class="card center mt16">
+        <button id="btnNew" class="btn primary">새 캐릭터 만들기</button>
+      </div>
+    </section>
+  `;
+  root.querySelectorAll('.clickable').forEach(el=>{
+    el.onclick = ()=> location.hash = `#/char/${el.dataset.id}`;
+  });
+  root.querySelector('#btnNew').onclick = ()=> location.hash = '#/create';
 }
-
-function createCard(){
-  const go = ()=> location.hash = '#/adventure';
-  return el('div',{ className:'card', onclick:go, style:'cursor:pointer;text-align:center' },
-    el('div',{ className:'title' }, '새 캐릭터 만들기'),
-    el('div',{ className:'muted' }, '세계관과 장소를 선택해 시작할 수 있어.')
-  );
-}
-
-function render(){
-  const v = document.getElementById('view');
-  const list = (App.state.chars||[]).map(charCard);
-  // 생성 카드를 "맨 아래" 배치
-  v.replaceChildren(
-    el('div',{ className:'stack' },
-      ...list,
-      createCard()
-    )
-  );
-}
-
-window.addEventListener('route', e => { if (e.detail.path === 'home') render(); });
-render();

--- a/public/js/tabs/me.js
+++ b/public/js/tabs/me.js
@@ -1,12 +1,26 @@
 // me.js — BYOK 로컬 저장 & 통계
-import { App, saveLocal } from '../api/store.js';
 import { el } from '../ui/components.js';
+import { setByok } from '../api/ai.js';
 
+function byokBox(){
+  const box = el('div',{ className:'card' },
+    el('div',{ className:'title' }, 'AI 키(BYOK)'),
+    el('div',{ className:'muted' }, 'Google Gemini API 키를 여기 입력. 로컬에만 저장돼.'),
+    el('input',{ id:'byokInput', placeholder:'AIza...', style:'width:100%' }),
+    el('button',{ className:'btn', onclick:()=>{
+      const val = document.getElementById('byokInput').value.trim();
+      setByok(val);
+      showToast && showToast('저장 완료 (로컬)');
+    }}, '저장')
+  );
+  return box;
+}
 
 function render(){
-const v=document.getElementById('view');
-const input=el('input',{className:'input', placeholder:'BYOK(내 AI 키) — 로컬만', value:App.state.settings.byok||''});
-input.oninput=()=>{ App.state.settings.byok=input.value.trim(); saveLocal(); };
-v.replaceChildren(el('div',{className:'col'}, el('div',{className:'title'},'내 정보'), input));
+  const v=document.getElementById('view');
+  v.replaceChildren(el('div',{className:'stack'},
+    el('div',{className:'title'},'내 정보'),
+    byokBox()
+  ));
 }
 window.addEventListener('route', e=>{ if(e.detail.path==='me') render(); });

--- a/public/js/utils/text.js
+++ b/public/js/utils/text.js
@@ -1,0 +1,15 @@
+export function countChars(s){ return (s||'').length; }
+export function countSentences(s){
+  if(!s) return 0;
+  return (s.trim().match(/[\.!?]\s|\n|$/g)||[]).length;
+}
+export function withinLimits({name, info, narrative, summary, abilities}){
+  const okName = countChars(name) <= 20;
+  const okInfo = countChars(info) <= 500;
+  const okNar  = countChars(narrative||'') <= 1000 && countSentences(narrative||'') <= 20;
+  const okSum  = countChars(summary||'')   <= 200 && countSentences(summary||'')   <= 8;
+  const okAb   = (abilities||[]).length===4 && abilities.every(a=>(
+    countChars(a.name)<=20 && countChars(a.desc_raw||a.desc||'')<=100 && countSentences(a.desc_raw||a.desc||'')<=4
+  ));
+  return okName && okInfo && okNar && okSum && okAb;
+}

--- a/storage.rules
+++ b/storage.rules
@@ -1,9 +1,11 @@
+rules_version = '2';
 service firebase.storage {
-match /b/{bucket}/o {
-function isSignedIn() { return request.auth != null; }
-match /uploads/{uid}/{allPaths=**} {
-allow read: if true; // 썸네일/이미지 공개 가정
-allow write: if isSignedIn() && request.auth.uid == uid && request.resource.size < 10 * 1024 * 1024; // 10MB 제한
-}
-}
+  match /b/{bucket}/o {
+    match /char_avatars/{uid}/{charId}/{fileName=**} {
+      allow read: if true;
+      allow write: if request.auth != null && request.auth.uid == uid
+                   && request.resource.size < 2 * 1024 * 1024
+                   && request.resource.contentType.matches('image/.*');
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- Replace Firebase API wrapper and store for server-backed character data, tier utilities, and avatar uploads
- Rework router and tabs to support home listing, character detail, and minimal create form
- Style updates and Firebase security rules for character and avatar data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68baa05248488320973abc7055e93159