### PR TITLE
feat: add character creation and detail views

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,26 +1,31 @@
+rules_version = '2';
 service cloud.firestore {
-match /databases/{database}/documents {
-function isSignedIn() { return request.auth != null; }
-function isOwner(uid) { return isSignedIn() && request.auth.uid == uid; }
+  match /databases/{database}/documents {
 
+    match /chars/{charId} {
+      allow read: if true;
+      allow create: if request.auth != null
+        && request.resource.data.owner_uid == request.auth.uid;
+      allow update, delete: if request.auth != null
+        && request.auth.uid == resource.data.owner_uid;
+    }
 
-match /chars/{charId} {
-allow read: if true; // 공개 프로필(필요 시 제한)
-allow create: if isSignedIn() && request.resource.data.owner_uid == request.auth.uid;
-allow update, delete: if isOwner(resource.data.owner_uid);
-}
+    match /char_items/{docId} {
+      allow read: if true;
+      allow write: if request.auth != null;
+    }
 
+    match /items/{itemId} {
+      allow read: if true;
+      allow write: if false; // 전역 마스터는 수동 관리
+    }
 
-match /encounters/{encId} {
-allow read: if true;
-allow create: if isSignedIn(); // 서버 타임스탬프 검증 권장
-allow update, delete: if isOwner(resource.data.created_by);
-}
+    match /encounters/{encId} {
+      allow read, write: if request.auth != null;
+    }
 
-
-match /profiles/{uid} {
-allow read: if true;
-allow write: if isOwner(uid);
-}
-}
+    match /relations/{docId} {
+      allow read, write: if request.auth != null;
+    }
+  }
 }

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -75,3 +75,42 @@ body{margin:0;background:var(--bg);color:var(--text);font:14px/1.5 system-ui, -a
 .site-list { display:flex; flex-direction:column; gap:8px; }
 .site-item { border:1px solid #223; border-radius:12px; padding:10px; cursor:pointer; }
 .site-item.sel { outline:2px solid #2f6df6; }
+/* === ToH additions === */
+.container.narrow { max-width: 720px; margin: 0 auto; padding: 16px; }
+.card { background:#1b1e23; border:1px solid #2a2f36; border-radius:14px; }
+.p0{padding:0} .p12{padding:12px} .p16{padding:16px}
+.mt6{margin-top:6px} .mt8{margin-top:8px} .mt12{margin-top:12px} .mt16{margin-top:16px}
+.row{display:flex;gap:12px;align-items:center}
+.col{display:flex;flex-direction:column}
+.center{display:flex;justify-content:center;align-items:center}
+.title{font-weight:600}
+.text-dim{opacity:.7}
+.btn{padding:10px 14px;border-radius:10px;border:1px solid #39414b;background:#2a3140}
+.btn.primary{background:#4062ff;border-color:#4062ff} .btn.large{padding:12px 18px;font-weight:600}
+.btn.ghost{background:transparent;border-color:#39414b}
+.icon-btn{border:1px solid #39414b;background:#2a3140;padding:6px 10px;border-radius:10px}
+.icon-btn.heart{border-radius:50%}
+.input,.textarea{width:100%;border-radius:10px;border:1px solid #39414b;background:#0f1216;color:#ddd;padding:10px}
+.chips{display:flex;gap:8px;flex-wrap:wrap}
+.chip{padding:6px 10px;border-radius:999px;border:1px solid #39414b;background:#151922}
+.chip.active{background:#4062ff;border-color:#4062ff}
+.thumb.sq{width:64px;height:64px;border-radius:12px;background:#101318}
+.avatar-wrap{position:relative;width:144px;height:144px;border-radius:16px;overflow:hidden}
+.avatar-wrap img{width:100%;height:100%;object-fit:cover}
+.avatar-wrap img.noimg{background:#0f1216}
+.stats4{display:grid;grid-template-columns:repeat(4,1fr);gap:8px;margin-top:12px}
+.pill{display:inline-flex;gap:6px;align-items:center;padding:6px 10px;border-radius:10px;background:#141922;border:1px solid #2b313a}
+.pill.white .v{color:#fff}
+.pill.pink .v{color:#ff69b4}
+.pill.gold .v{color:#ffd166}
+.pill.red .v{color:#ff6b6b}
+.actions .btn{min-width:140px}
+.tabbar{display:flex;gap:8px;border-bottom:1px solid #2a2f36;padding:8px}
+.tab{padding:8px 12px;border:0;background:transparent;border-bottom:2px solid transparent}
+.tab.active{border-color:#4062ff}
+.subtabs{display:flex;gap:8px;border-bottom:1px dashed #2a2f36;padding:8px 16px}
+.sub{padding:6px 10px;border:0;background:transparent;border-bottom:2px solid transparent}
+.sub.active{border-color:#4062ff}
+.grid2{display:grid;grid-template-columns:1fr 1fr;gap:8px}
+.grid3{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}
+.skill input{margin-right:8px}

--- a/public/js/api/firebase.js
+++ b/public/js/api/firebase.js
@@ -1,41 +1,32 @@
-// Firebase SDK v10+ modular
+// --- Firebase SDK v10+ modular ---
 import { initializeApp } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-app.js';
 import {
   getAuth, GoogleAuthProvider, onAuthStateChanged, signInWithPopup, signOut
 } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-auth.js';
 import {
-  getFirestore, collection, doc, setDoc, getDoc, addDoc, updateDoc, getDocs,
-  query, where, orderBy, limit, serverTimestamp, runTransaction, increment
+  getFirestore, doc, getDoc, setDoc, addDoc, updateDoc,
+  collection, query, where, getDocs, orderBy, limit, serverTimestamp
 } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-firestore.js';
 import {
-  getStorage, ref, uploadBytes, getDownloadURL, updateMetadata
+  getStorage, ref, uploadBytes, getDownloadURL
 } from 'https://www.gstatic.com/firebasejs/10.12.2/firebase-storage.js';
 
-
-// ✅ Firebase 프로젝트 설정
+// !! 여기에 네 프로젝트 설정값 유지 !!
 const firebaseConfig = {
   apiKey: "AIzaSyA4ilV6tRpqZrkgXRTKdFP_YjAl3CmfYWo",
   authDomain: "tale-of-heros---fangame.firebaseapp.com",
   projectId: "tale-of-heros---fangame",
-  storageBucket: "tale-of-heros---fangame.appspot.com", // 꼭 appspot.com 형식
+  storageBucket: "tale-of-heros---fangame.firebasestorage.app",
   messagingSenderId: "648588906865",
   appId: "1:648588906865:web:eb4baf1c0ed9cdbc7ba6d0"
 };
 
 export const app = initializeApp(firebaseConfig);
-
-// Auth
 export const auth = getAuth(app);
 export const provider = new GoogleAuthProvider();
-export const ax = { onAuthStateChanged, signInWithPopup, signOut };
-
-// Firestore
 export const db = getFirestore(app);
-export const fx = {
-  collection, doc, setDoc, getDoc, addDoc, updateDoc, getDocs,
-  query, where, orderBy, limit, serverTimestamp, runTransaction, increment
-};
-
-// Storage
 export const storage = getStorage(app);
-export const sx = { ref, uploadBytes, getDownloadURL, updateMetadata };
+
+export const fx = { doc, getDoc, setDoc, addDoc, updateDoc, collection, query, where, getDocs, orderBy, limit, serverTimestamp };
+export const sx = { ref, uploadBytes, getDownloadURL };
+export const ax = { onAuthStateChanged, signInWithPopup, signOut };

--- a/public/js/api/store.js
+++ b/public/js/api/store.js
@@ -1,240 +1,105 @@
-// store.js
-import { db, fx } from './firebase.js';
+import { db, auth, fx, storage, sx } from './firebase.js';
 import { showToast } from '../ui/toast.js';
 
-// 생성 잠금 & 리롤 쿨다운 상태
-export let creationLock = false;
-export function lockCreation(b){ creationLock = !!b; }
-
-export function canRerollToday(char){
-  const d = new Date(); const today = d.toISOString().slice(0,10);
-  const last = char._lastRerollDay || '';
-  return last !== today && (char._rerollsToday||0) < (char._rerollLimit||1);
-}
-export function markReroll(char){
-  const d = new Date(); const today = d.toISOString().slice(0,10);
-  if(char._lastRerollDay !== today){ char._lastRerollDay = today; char._rerollsToday = 0; }
-  char._rerollsToday = (char._rerollsToday||0) + 1;
-}
-
-const KEY = {
-  chars: 'toh_chars',
-  worlds: 'toh_worlds',
-  enc: 'toh_enc',
-  settings: 'toh_settings',
-  weekly: 'toh_weekly',
-  rankings: 'toh_rankings'
-};
-
-// ★ App은 한 번만!
 export const App = {
-  // 화면에서 쓰는 상태는 여기에 통일
   state: {
     user: null,
     worlds: null,
-    chars: [],
-    enc: [],
-    settings: { byok: '' },
-  },
-  currentWorldId: 'gionkir',
-  user: null,         // onAuthChanged에서 채움(편의상 루트도 유지)
-  rankings: null      // 랭킹 캐시
+    currentWorldId: 'gionkir',
+    myChars: [],        // 항상 서버→메모리
+  }
 };
 
-// -------------------- 로컬 캐시 --------------------
+// ----- 유틸 -----
+export function tierOf(elo=1000){
+  if (elo < 900) return {name:'Bronze',  color:'#7a5a3a'};
+  if (elo < 1100) return {name:'Silver',  color:'#8aa0b8'};
+  if (elo < 1300) return {name:'Gold',    color:'#d1a43f'};
+  if (elo < 1500) return {name:'Platinum',color:'#69c0c6'};
+  if (elo < 1700) return {name:'Diamond', color:'#7ec2ff'};
+  return {name:'Master', color:'#b678ff'};
+}
 
-export async function initLocalCache() {
-  // worlds 로컬 없으면 assets/worlds.json 로드
-  let w = null;
-  try { w = JSON.parse(localStorage.getItem(KEY.worlds) || 'null'); } catch {}
-  if (!w) {
-    w = await fetch('/assets/worlds.json').then(r => r.json());
-    localStorage.setItem(KEY.worlds, JSON.stringify(w));
-  }
+export async function fetchWorlds(){
+  if (App.state.worlds) return App.state.worlds;
+  const w = await fetch('/assets/worlds.json').then(r=>r.json());
   App.state.worlds = w;
-
-  // 나머지 로컬 우선
-  try { App.state.chars = JSON.parse(localStorage.getItem(KEY.chars) || '[]'); } catch { App.state.chars = []; }
-  try { App.state.enc   = JSON.parse(localStorage.getItem(KEY.enc)   || '[]'); } catch { App.state.enc = []; }
-  try { App.state.settings = JSON.parse(localStorage.getItem(KEY.settings) || '{"byok":""}'); } catch { App.state.settings = { byok: '' }; }
-
-  // 씨드가 필요하면(선택) — seedDemo가 없으면 건너뜀
-  if (!App.state.chars.length && typeof window.seedDemo === 'function') {
-    window.seedDemo(); // 너가 만든 함수가 있을 때만 호출
-  }
+  return w;
 }
 
-export function saveLocal() {
-  localStorage.setItem(KEY.chars, JSON.stringify(App.state.chars));
-  localStorage.setItem(KEY.enc, JSON.stringify(App.state.enc));
-  localStorage.setItem(KEY.settings, JSON.stringify(App.state.settings));
+// ----- Auth 후크 밖에서 호출하는 “읽기/쓰기” 래퍼 -----
+export async function fetchMyChars(uid){
+  const q = fx.query(fx.collection(db,'chars'), fx.where('owner_uid','==', uid));
+  const s = await fx.getDocs(q);
+  const arr = [];
+  s.forEach(d => arr.push({ id: d.id, ...d.data() }));
+  App.state.myChars = arr;
+  return arr;
 }
 
-export function exportAll() {
-  const blob = new Blob(
-    [JSON.stringify({ chars: App.state.chars, enc: App.state.enc, worlds: App.state.worlds }, null, 2)],
-    { type: 'application/json' }
-  );
-  const a = document.createElement('a');
-  a.href = URL.createObjectURL(blob);
-  a.download = 'toh-export.json';
-  a.click();
-  URL.revokeObjectURL(a.href);
-}
-
-export function importAll(e) {
-  const f = e.target.files?.[0]; if (!f) return;
-  const r = new FileReader();
-  r.onload = () => {
-    try {
-      const data = JSON.parse(r.result);
-      if (data.worlds) { App.state.worlds = data.worlds; localStorage.setItem(KEY.worlds, JSON.stringify(data.worlds)); }
-      if (data.chars)  { App.state.chars  = data.chars;  saveLocal(); }
-      if (data.enc)    { App.state.enc    = data.enc;    saveLocal(); }
-      showToast('불러오기 완료'); location.hash = '#/home';
-    } catch {
-      showToast('불러오기 실패');
-    }
-  };
-  r.readAsText(f);
-}
-
-export function setWorldChip() {
-  const el = document.getElementById('worldChip');
-  if (!el) return;
-  const w = App.state.worlds?.worlds?.find(x => x.id === App.currentWorldId);
-  el.textContent = '세계관: ' + (w?.name || '-');
-}
-
-export function ensureWeeklyReset() {
-  const KSTMonday00 = lastWeeklyResetKST();
-  const mark = +(localStorage.getItem(KEY.weekly) || 0);
-  if (mark < KSTMonday00) {
-    App.state.chars.forEach(c => c.likes_weekly = 0);
-    saveLocal();
-    localStorage.setItem(KEY.weekly, KSTMonday00);
-  }
-}
-
-function lastWeeklyResetKST() {
-  const d = new Date();
-  const utc = d.getTime() + d.getTimezoneOffset() * 60000;
-  const kst = new Date(utc + 9 * 3600 * 1000);
-  kst.setHours(0, 0, 0, 0);
-  const dow = kst.getDay(); // 0=Sun
-  const need = 1; // Mon
-  const diff = (dow >= need ? dow - need : 7 - (need - dow));
-  kst.setDate(kst.getDate() - diff);
-  // 다시 로컬 epoch로
-  const back = kst.getTime() - 9 * 3600 * 1000 - d.getTimezoneOffset() * 60000;
-  return back;
-}
-
-
-// ---------- 랭킹: Firestore에서 읽기 ----------
-export async function loadRankingsFromServer(topN = 50){
-  const col  = fx.collection(db, 'chars');
-  const take = (field)=> fx.getDocs(fx.query(col, fx.orderBy(field,'desc'), fx.limit(topN)));
-  const [w,t,e] = await Promise.all([ take('likes_weekly'), take('likes_total'), take('elo') ]);
-
-  const toArr = (snap)=>{ const arr=[]; snap.forEach(d=> arr.push({ id:d.id, ...d.data() })); return arr; };
-  App.rankings = { weekly: toArr(w), total: toArr(t), elo: toArr(e), fetchedAt: Date.now() };
-  try { localStorage.setItem(KEY.rankings, JSON.stringify(App.rankings)); } catch {}
-  return App.rankings;
-}
-export function restoreRankingCache(){
-  try{ const raw = localStorage.getItem(KEY.rankings); if(raw) App.rankings = JSON.parse(raw); }catch{}
-}
-
-
-// ---------- 좋아요 (7일 쿨타임) ----------
-const RELIKE_MS = 7 * 24 * 60 * 60 * 1000;
-
-export async function likeCharacter(charId, currentUser){
-  if(!currentUser){ showToast && showToast('로그인이 필요해'); return; }
-  const uid = currentUser.uid;
-
-  // 내 좋아요 기록
-  const likeDocRef = fx.doc(db, 'chars', charId, 'likes', uid);
-  const likeDoc    = await fx.getDoc(likeDocRef);
+export async function createCharMinimal({ world_id, name, input_info }){
+  const u = auth.currentUser;
+  if(!u) throw new Error('로그인이 필요해');
   const now = Date.now();
-  if (likeDoc.exists()){
-    const last = likeDoc.data().lastLikedAt?.toMillis?.() ?? likeDoc.data().lastLikedAt ?? 0;
-    const remain = last + RELIKE_MS - now;
-    if (remain > 0){
-      const days = Math.ceil(remain / (24*60*60*1000));
-      showToast && showToast(`아직 ${days}일 남았어. 일주일 후에 다시 가능해!`);
-      return;
-    }
-  }
-
-  // 기록 갱신
-  await fx.setDoc(likeDocRef, { uid, lastLikedAt: fx.serverTimestamp() }, { merge:true });
-
-  // 캐릭 카운트 +1 (규칙에서 +1만 허용)
-  const charRef = fx.doc(db, 'chars', charId);
-  await fx.setDoc(charRef, {
-    likes_total:  fx.increment(1),
-    likes_weekly: fx.increment(1)
-  }, { merge:true });
-
-  // 로컬 반영(있으면)
-  const i = App.state.chars.findIndex(c=> (c.char_id||c.id) === charId);
-  if(i>=0){
-    const c = App.state.chars[i];
-    c.likes_total  = (c.likes_total  || 0) + 1;
-    c.likes_weekly = (c.likes_weekly || 0) + 1;
-    saveLocal();
-  }
-  showToast && showToast('좋아요! 💙');
-
-  // (선택) 랭킹 새로고침
-  try { await loadRankingsFromServer(); } catch {}
-}
-
-// ---------- Elo 업데이트(두 캐릭 동시에) ----------
-function expectedScore(rA, rB){ return 1 / (1 + Math.pow(10, (rB - rA) / 400)); }
-
-export async function applyBattleResult(charAId, charBId, verdict, K=32){
-  const aRef = fx.doc(db, 'chars', charAId);
-  const bRef = fx.doc(db, 'chars', charBId);
-
-  await fx.runTransaction(db, async (tx)=>{
-    const aSnap = await tx.get(aRef);
-    const bSnap = await tx.get(bRef);
-    if(!aSnap.exists() || !bSnap.exists()) throw new Error('캐릭터 없음');
-
-    const A = aSnap.data(), B = bSnap.data();
-    const RA = A.elo ?? 1200, RB = B.elo ?? 1200;
-
-    let SA = 0.5, SB = 0.5;
-    if (verdict==='win')  { SA=1; SB=0; }
-    if (verdict==='loss') { SA=0; SB=1; }
-
-    const EA = expectedScore(RA, RB), EB = expectedScore(RB, RA);
-    const newRA = Math.round(RA + K * (SA - EA));
-    const newRB = Math.round(RB + K * (SB - EB));
-
-    tx.set(aRef, {
-      elo:newRA,
-      wins:(A.wins||0)+(verdict==='win'?1:0),
-      losses:(A.losses||0)+(verdict==='loss'?1:0),
-      draws:(A.draws||0)+(verdict==='draw'?1:0)
-    },{merge:true});
-    tx.set(bRef, {
-      elo:newRB,
-      wins:(B.wins||0)+(verdict==='loss'?1:0),
-      losses:(B.losses||0)+(verdict==='win'?1:0),
-      draws:(B.draws||0)+(verdict==='draw'?1:0)
-    },{merge:true});
+  const docRef = await fx.addDoc(fx.collection(db,'chars'), {
+    owner_uid: u.uid,
+    world_id, name, input_info,
+    image_url: '',
+    abilities_all: [
+      {name:'',desc_raw:'',desc_soft:''},
+      {name:'',desc_raw:'',desc_soft:''},
+      {name:'',desc_raw:'',desc_soft:''},
+      {name:'',desc_raw:'',desc_soft:''}
+    ],
+    abilities_equipped: [0,1],
+    items_equipped: [],
+    narrative: '',
+    summary: '',
+    summary_line: '',
+    elo: 1000, wins:0, losses:0, draws:0,
+    likes_total:0, likes_weekly:0,
+    battle_count:0, explore_count:0,
+    createdAt: now, updatedAt: now
   });
+  showToast('캐릭터가 생성되었어!');
+  return docRef.id;
 }
 
-// 서버에 캐릭터 정보 업서트 (옵션)
-export async function upsertCharToServer(c){
-  // 서버 연동이 준비되지 않았다면 아무 것도 하지 않음
-  try {
-    const ref = fx.doc(db, 'chars', c.char_id || c.id);
-    await fx.setDoc(ref, c, { merge: true });
-  } catch {}
+export async function updateAbilitiesEquipped(charId, indices){
+  const u = auth.currentUser; if(!u) return;
+  if(!Array.isArray(indices) || indices.length !== 2) return;
+  await fx.updateDoc(fx.doc(db,'chars',charId), { abilities_equipped: indices, updatedAt: Date.now() });
+  showToast('스킬 장착 변경');
+}
+
+export async function updateItemsEquipped(charId, charItemDocIds /* length ≤3 */){
+  const u = auth.currentUser; if(!u) return;
+  const safe = (charItemDocIds||[]).slice(0,3);
+  await fx.updateDoc(fx.doc(db,'chars',charId), { items_equipped: safe, updatedAt: Date.now() });
+  showToast('아이템 장착 변경');
+}
+
+// ----- 이미지 1:1 업로드(512x512 중앙 크롭) -----
+export async function uploadAvatarSquare(charId, file){
+  const u = auth.currentUser;
+  if(!u) throw new Error('로그인이 필요해');
+  const bmp = await createImageBitmap(await file.arrayBuffer().then(b=>new Blob([b])));
+  const size = Math.min(bmp.width, bmp.height);
+  const sx0 = (bmp.width  - size)/2;
+  const sy0 = (bmp.height - size)/2;
+
+  const canvas = document.createElement('canvas');
+  canvas.width = 512; canvas.height = 512;
+  const ctx = canvas.getContext('2d');
+  ctx.imageSmoothingEnabled = true;
+  ctx.drawImage(bmp, sx0, sy0, size, size, 0, 0, 512, 512);
+
+  const blob = await new Promise(res => canvas.toBlob(res, 'image/jpeg', 0.85));
+  const path = `char_avatars/${u.uid}/${charId}/v${Date.now()}.jpg`;
+  const r = sx.ref(storage, path);
+  await sx.uploadBytes(r, blob, { contentType: 'image/jpeg', cacheControl: 'public,max-age=31536000,immutable' });
+  const url = await sx.getDownloadURL(r);
+  await fx.updateDoc(fx.doc(db,'chars',charId), { image_url: url, updatedAt: Date.now() });
+  showToast('아바타 업로드 완료');
+  return url;
 }

--- a/public/js/router.js
+++ b/public/js/router.js
@@ -1,9 +1,21 @@
+import { showHome } from './tabs/home.js';
+import { showAdventure } from './tabs/adventure.js';
+import { showRankings } from './tabs/rankings.js';
+import { showFriends } from './tabs/friends.js';
+import { showMe } from './tabs/me.js';
+import { showRelations } from './tabs/relations.js';
+import { showCharDetail } from './tabs/char.js';
+import { showCreate } from './tabs/create.js';
+
 export const routes = {
-  home:      { path: /^#\/home$/,            tab: 'home' },
-  adventure: { path: /^#\/adventure$/,       tab: 'adventure' },
-  rankings:  { path: /^#\/rankings$/,        tab: 'rankings' },
-  char:      { path: /^#\/char\/(.+)$/,      tab: 'char' },
-  create:    { path: /^#\/create$/,          tab: 'create' }
+  '#/home': showHome,
+  '#/adventure': showAdventure,
+  '#/rankings': showRankings,
+  '#/friends': showFriends,
+  '#/me': showMe,
+  '#/relations': showRelations,
+  '#/char': showCharDetail,   // 사용법: #/char/:id
+  '#/create': showCreate
 };
 
 export function highlightTab(){
@@ -14,10 +26,13 @@ export function highlightTab(){
   });
 }
 
-
 export function router(){
   const hash = location.hash || '#/home';
-  const [_, path, id] = hash.split('/');
-  const event = new CustomEvent('route', { detail: { path, id } });
-  window.dispatchEvent(event);
+  if(hash.startsWith('#/char/')){
+    routes['#/char']();
+  }else if(routes[hash]){
+    routes[hash]();
+  }else{
+    routes['#/home']();
+  }
 }

--- a/public/js/tabs/char.js
+++ b/public/js/tabs/char.js
@@ -1,129 +1,194 @@
-// public/js/tabs/char.js
-import { App, saveLocal, likeCharacter, canRerollToday, markReroll } from '../api/store.js';
-import { el } from '../ui/components.js';
-import { storage, sx } from '../api/firebase.js';
-import { auth } from '../api/auth.js';
+import { db, auth, fx } from '../api/firebase.js';
+import { App, tierOf, uploadAvatarSquare, updateAbilitiesEquipped, updateItemsEquipped } from '../api/store.js';
 import { showToast } from '../ui/toast.js';
-import { rerollSkills } from '../api/ai.js';
 
-function makeFileInput(onChange){
-  const input = el('input', {
-    type:'file',
-    accept:'image/*',
-    capture:'environment',
-    style:'display:none'
-  });
-  input.onchange = onChange;
-  document.body.appendChild(input);
-  return input;
+function parseId(){
+  const hash = location.hash || '';
+  const m = hash.match(/^#\/char\/(.+)$/);
+  return m ? m[1] : null;
 }
 
-async function handleUpload(c){
-  const picker = makeFileInput(async (e)=>{
-    const f = e.target.files && e.target.files[0];
-    if(!f) return;
+export async function showCharDetail(){
+  const id = parseId();
+  if(!id){ document.getElementById('view').innerHTML='<p>잘못된 경로</p>'; return; }
+  const doc = await fx.getDoc(fx.doc(db,'chars',id));
+  if(!doc.exists()){ document.getElementById('view').innerHTML='<p>캐릭터가 없네</p>'; return; }
+  const c = { id: doc.id, ...doc.data() };
+  render(c);
+}
 
-    const uid = (auth && auth.currentUser && auth.currentUser.uid) || 'anon';
-    const safe = `${Date.now()}_${(f.name||'img').replace(/[^a-zA-Z0-9._-]/g,'_')}`;
-    const r = sx.ref(storage, `uploads/${uid}/${c.char_id || c.id}/${safe}`);
+function rateText(w,l){ const t=w+l; if(!t) return '0%'; return Math.round(w*100/t)+'%'; }
 
-    await sx.uploadBytes(r, f, {
-      contentType: f.type || 'image/jpeg',
-      cacheControl: 'public, max-age=31536000, immutable'
+async function handleUpload(id){
+  const input = document.createElement('input');
+  input.type='file'; input.accept='image/*';
+  input.onchange = async ()=>{
+    const f = input.files?.[0]; if(!f) return;
+    await uploadAvatarSquare(id, f);
+    location.reload();
+  };
+  input.click();
+}
+
+async function fetchInventory(charId){
+  const q = fx.query(fx.collection(db,'char_items'), fx.where('char_id','==', `chars/${charId}`));
+  const s = await fx.getDocs(q);
+  const arr=[]; s.forEach(d=>arr.push({id:d.id, ...d.data()}));
+  return arr;
+}
+
+function render(c){
+  const root = document.getElementById('view');
+  const tier = tierOf(c.elo);
+  const isOwner = auth.currentUser && c.owner_uid === auth.currentUser.uid;
+
+  root.innerHTML = `
+  <section class="container narrow">
+    <div class="char-top card p16">
+      <div class="avatar-wrap" style="border:3px solid ${tier.color}">
+        <img src="${c.image_url||''}" alt="" onerror="this.src=''; this.classList.add('noimg')" />
+        ${isOwner? `<button id="btnUpload" class="icon-btn">업로드</button>`:''}
+      </div>
+      <div class="meta">
+        <h3 class="name">${c.name}</h3>
+        <div class="chips"><span class="chip">${c.world_id}</span></div>
+        <div class="like-area"><button class="icon-btn heart" id="btnLike">♥</button></div>
+      </div>
+
+      <div class="stats4">
+        <div class="stat pill white"><div class="k">승률</div><div class="v">${rateText(c.wins,c.losses)}</div></div>
+        <div class="stat pill pink"><div class="k">누적 좋아요</div><div class="v">${c.likes_total||0}</div></div>
+        <div class="stat pill gold"><div class="k">Elo</div><div class="v">${c.elo||1000}</div></div>
+        <div class="stat pill red"><div class="k">주간 좋아요</div><div class="v">${c.likes_weekly||0}</div></div>
+      </div>
+      <div class="counts mt6 text-dim">전투 ${c.battle_count||0} · 탐험 ${c.explore_count||0}</div>
+
+      <div class="actions center mt16">
+        <button class="btn large" id="btnBattle">배틀 시작</button>
+        <button class="btn large ghost" id="btnEncounter">조우 시작</button>
+      </div>
+    </div>
+
+    <div class="tabs card p0 mt16">
+      <div class="tabbar">
+        <button class="tab active" data-t="bio">서사/에피소드/관계</button>
+        <button class="tab" data-t="loadout">스킬/아이템</button>
+        <button class="tab" data-t="history">전적</button>
+      </div>
+      <div class="tabview" id="tabview"></div>
+    </div>
+  </section>
+  `;
+
+  // 버튼
+  if(isOwner){ root.querySelector('#btnUpload')?.addEventListener('click', ()=>handleUpload(c.id)); }
+
+  // 좋아요(추후 구현)
+  root.querySelector('#btnLike').onclick = ()=> showToast('좋아요는 나중에!');
+
+  // 탭
+  const view = root.querySelector('#tabview');
+  const tabs = root.querySelectorAll('.tabbar .tab');
+  tabs.forEach(b=>b.onclick = ()=>{ tabs.forEach(x=>x.classList.remove('active')); b.classList.add('active'); renderTab(b.dataset.t, c, view); });
+  renderTab('bio', c, view);
+
+  root.querySelector('#btnBattle').onclick   = ()=> showToast('매칭 로직은 다음 패치에서!');
+  root.querySelector('#btnEncounter').onclick= ()=> showToast('조우 매칭도 다음 패치에서!');
+}
+
+function renderTab(which, c, view){
+  if(which==='bio'){
+    view.innerHTML = `
+      <div class="subtabs">
+        <button class="sub active" data-s="narr">서사</button>
+        <button class="sub" data-s="epis">미니 에피소드</button>
+        <button class="sub" data-s="rel">관계</button>
+      </div>
+      <div id="subview" class="p16"></div>
+    `;
+    const sv = view.querySelector('#subview');
+    const subs = view.querySelectorAll('.subtabs .sub');
+    subs.forEach(b=>b.onclick=()=>{ subs.forEach(x=>x.classList.remove('active')); b.classList.add('active'); renderSub(b.dataset.s,c,sv); });
+    renderSub('narr',c,sv);
+  }
+  if(which==='loadout'){
+    renderLoadout(c, view);
+  }
+  if(which==='history'){
+    view.innerHTML = `<div class="p16">전적은 곧 들어가!</div>`;
+  }
+}
+
+function renderSub(s, c, sv){
+  if(s==='narr'){
+    sv.innerHTML = `
+      <div class="mb8 text-dim">한줄 요약</div>
+      <div class="card p12">${c.summary_line||'-'}</div>
+      <div class="mb8 mt16 text-dim">기본 소개</div>
+      <div class="card p12">${c.summary||'-'}</div>
+      <div class="mb8 mt16 text-dim">탄생 배경</div>
+      <div class="card p12">${c.narrative||'-'}</div>
+    `;
+  } else if(s==='epis'){
+    sv.innerHTML = `<div class="text-dim">미니 에피소드는 나중에 리스트로!</div>`;
+  } else if(s==='rel'){
+    sv.innerHTML = `<div class="text-dim">관계 메모는 배틀 후 10분 내 생성 · 양측 삭제 가능 (UI 추후)</div>`;
+  }
+}
+
+async function renderLoadout(c, view){
+  const isOwner = auth.currentUser && c.owner_uid === auth.currentUser.uid;
+  // 스킬(4개 중 2개)
+  let html = `
+    <div class="p16">
+      <h4>스킬 (4개 중 2개 선택)</h4>
+      <div class="grid2 mt8">
+        ${c.abilities_all.map((ab,i)=>`
+          <label class="card p12 skill">
+            <input type="checkbox" data-i="${i}" ${c.abilities_equipped?.includes(i)?'checked':''} ${!isOwner?'disabled':''}/>
+            <div class="name">${ab?.name||`능력 ${i+1}`}</div>
+            <div class="desc">${ab?.desc_soft||'-'}</div>
+          </label>`).join('')}
+      </div>
+    </div>
+  `;
+
+  // 아이템 장착 3칸 (인벤토리 간단 표기)
+  html += `
+    <div class="p16">
+      <h4 class="mt12">아이템 장착 (최대 3개)</h4>
+      <div id="itemsBox" class="grid3 mt8"></div>
+      ${isOwner? `<button id="btnEquip" class="btn mt8">인벤토리에서 선택</button>`:''}
+    </div>
+  `;
+
+  view.innerHTML = html;
+
+  // 스킬 체크: 2개 제한
+  const boxes = Array.from(view.querySelectorAll('.skill input[type=checkbox]'));
+  boxes.forEach(b=>{
+    b.onchange = ()=>{
+      const on = boxes.filter(x=>x.checked).map(x=>+x.dataset.i);
+      if(on.length>2){ b.checked=false; return showToast('스킬은 2개까지만!'); }
+      if(isOwner && on.length===2) updateAbilitiesEquipped(c.id, on);
+    };
+  });
+
+  // 아이템 3칸 표시(간단)
+  const inv = await fetchInventory(c.id);
+  const box = view.querySelector('#itemsBox');
+  const equipped = c.items_equipped||[];
+  box.innerHTML = [0,1,2].map(slot=>{
+    const docId = equipped[slot];
+    const label = docId ? (inv.find(i=>i.id===docId)?.item_id || '아이템') : '(비어 있음)';
+    return `<div class="card p12">${label}</div>`;
+  }).join('');
+
+  if(isOwner){
+    view.querySelector('#btnEquip')?.addEventListener('click', ()=>{
+      // 간단 토글: 앞 3개를 장착 예시 (실서비스에선 피커 UI)
+      const selected = inv.slice(0,3).map(x=>x.id);
+      updateItemsEquipped(c.id, selected);
     });
-    const url = await sx.getDownloadURL(r);
-
-    c.image_url = url;
-    saveLocal();
-    showToast && showToast('이미지 업로드 완료');
-    render(c.char_id || c.id);
-    picker.remove();
-  });
-  picker.click();
-}
-
-function render(charId){
-  const v = document.getElementById('view');
-  if(!v) return;
-
-  const c = App.state.chars.find(x => (x.char_id || x.id) === charId);
-  if(!c){
-    v.textContent = '캐릭터를 찾을 수 없어.';
-    return;
   }
-
-  const img = c.image_url
-    ? el('img', { src:c.image_url, style:'width:100%;max-height:240px;object-fit:cover;border-radius:12px;border:1px solid #212a36' })
-    : el('div',{ className:'card', style:'height:180px;display:flex;align-items:center;justify-content:center;color:#9aa4b2' }, '이미지 없음');
-
-  const info = el('div',{ className:'card' },
-    el('div',{ className:'title' }, c.name),
-    el('div',{ className:'muted' }, `세계관: ${c.world_id || '-'}`),
-    el('div',{},
-      el('span',{ className:'pill' }, '주간 ' + (c.likes_weekly || 0)),
-      el('span',{ className:'pill' }, '누적 ' + (c.likes_total  || 0)),
-      el('span',{ className:'pill' }, 'Elo '   + (c.elo          || 0))
-    ),
-    el('div',{ className:'hr' }),
-    el('div',{},
-      el('div',{ className:'muted' }, '소개'),
-      el('div',{}, c.summary || '(요약 없음)')
-    ),
-    el('div',{ className:'hr' }),
-    el('div',{},
-      el('div',{ className:'muted' }, '능력'),
-      ...((c.abilities || []).map(a =>
-        el('div',{ className:'row' },
-          el('span',{ className:'pill' }, a.name),
-          el('div',{}, a.desc || a.desc_raw || '')
-        )
-      ))
-    )
-  );
-
-  const btnUpload = el('button',{ className:'btn pri', onclick:()=>handleUpload(c) },
-    c.image_url ? '이미지 변경' : '이미지 업로드'
-  );
-
-  const btnLike = el('button',{ className:'btn',
-    onclick:()=> likeCharacter(c.char_id || c.id, auth.currentUser)
-  }, '좋아요');
-
-  const btnReroll = el('button',{ className:'btn', onclick: async ()=>{
-    if(!canRerollToday(c)){ showToast && showToast('오늘 리롤 한도를 초과했어.'); return; }
-    const worldName = (App.state.worlds?.worlds||[]).find(w=>w.id===c.world_id)?.name || '';
-    try{
-      const raw = await rerollSkills({ name: c.name, worldName, info: c.input_info||'' });
-      const data = JSON.parse(raw);
-      if(Array.isArray(data.abilities) && data.abilities.length===4){
-        // 미리보기 선택
-        if(confirm('새 스킬로 교체할까?')){
-          c.abilities = data.abilities.map(x=>({ name:x.name||'', desc:x.desc_soft||x.desc||'', desc_raw:x.desc_raw||x.desc||'' }));
-          markReroll(c);
-          saveLocal();
-          showToast && showToast('리롤 완료!');
-          render(c.char_id || c.id);
-        }
-      } else {
-        showToast && showToast('리롤 실패: 형식 오류');
-      }
-    }catch(e){ showToast && showToast(e.message||'리롤 실패'); }
-  }}, '스킬 리롤');
-
-  const btnBack = el('button',{ className:'btn', onclick:()=>history.back() }, '← 돌아가기');
-
-  v.replaceChildren(
-    el('div',{ className:'col', style:'gap:12px' },
-      img,
-      el('div',{ className:'row', style:'gap:8px' }, btnUpload, btnLike, btnReroll),
-      info,
-      el('div',{}, btnBack)
-    )
-  );
 }
-
-window.addEventListener('route', (e)=>{
-  if(e.detail && e.detail.path === 'char' && e.detail.id){
-    render(e.detail.id);
-  }
-});

--- a/public/js/tabs/create.js
+++ b/public/js/tabs/create.js
@@ -1,173 +1,49 @@
-import { App, saveLocal } from '../api/store.js';
-import { el } from '../ui/components.js';
-import { withinLimits } from '../utils/text.js';
-import { genSketch, refineNarrative, rerollSkills } from '../api/ai.js';
-import { upsertCharToServer } from '../api/store.js'; // 이미 store.js에 있다면 사용
-import { lockCreation, creationLock } from '../api/store.js';
+import { fetchWorlds, createCharMinimal, App } from '../api/store.js';
+import { showToast } from '../ui/toast.js';
 
-const State = {
-  worldId: null,
-  name: '',
-  info: '',
-  abilities: [ {name:'',desc_raw:'',desc_soft:''}, {name:'',desc_raw:'',desc_soft:''}, {name:'',desc_raw:'',desc_soft:''}, {name:'',desc_raw:'',desc_soft:''} ],
-  narrative: '',
-  summary: '',
-  sketchPicked: null
-};
+export async function showCreate(){
+  const root = document.getElementById('view');
+  const worlds = await fetchWorlds();
+  const worldList = (worlds?.worlds||[]);
 
-function limitsRow(){
-  const ok = withinLimits({ name:State.name, info:State.info, narrative:State.narrative, summary:State.summary, abilities:State.abilities });
-  return el('div',{ className:'muted' }, ok ? '제한 OK' : '제한 초과 항목이 있어');
-}
+  root.innerHTML = `
+  <section class="container narrow">
+    <h2>새 캐릭터 만들기</h2>
+    <div class="card p16">
+      <label class="lbl">세계관</label>
+      <div class="chips" id="wchips">
+        ${worldList.map(w=>`<button class="chip" data-w="${w.id}">${w.name}</button>`).join('')}
+      </div>
 
-function worldChooser(){
-  const worlds = App.state.worlds?.worlds || [];
-  const chip = (w)=> el('span',{ className:'chip'+(State.worldId===w.id?' sel':''), onclick:()=>{ State.worldId=w.id; render(); } }, w.name);
-  return el('div',{}, el('div',{className:'muted'},'세계관 선택'), el('div',{className:'chips'}, ...worlds.map(chip)));
-}
+      <label class="lbl">이름 (≤20자)</label>
+      <input id="cname" maxlength="20" class="input" placeholder="이름" />
 
-function baseInputs(){
-  const iName = el('input',{ placeholder:'이름(≤20자)', value:State.name, oninput:(e)=>{ State.name=e.target.value; render(); } });
-  const iInfo = el('textarea',{ placeholder:'설정/정보(≤500자)', rows:4, value:State.info, oninput:(e)=>{ State.info=e.target.value; render(); } });
-  return el('div',{},
-    el('div',{className:'title'},'기본 입력'),
-    iName, iInfo
-  );
-}
+      <label class="lbl">설명 (≤500자)</label>
+      <textarea id="cinfo" maxlength="500" class="textarea" rows="6" placeholder="캐릭터 소개/설정"></textarea>
 
-function abilitiesBox(){
-  const rows = State.abilities.map((a,idx)=>
-    el('div',{className:'card'},
-      el('div',{className:'title'}, `능력 ${idx+1}`),
-      el('input',{ placeholder:'이름(≤20자)', value:a.name, oninput:(e)=>{ a.name=e.target.value; } }),
-      el('textarea',{ placeholder:'desc_raw(≤100자, ≤4문장)', rows:2, value:a.desc_raw||'', oninput:(e)=>{ a.desc_raw=e.target.value; } }),
-      el('textarea',{ placeholder:'desc_soft(완곡화)', rows:2, value:a.desc_soft||'', oninput:(e)=>{ a.desc_soft=e.target.value; } })
-    )
-  );
-  const btnReroll = el('button',{ className:'btn', onclick: onReroll }, '스킬 리롤(일 1회)');
-  return el('div',{}, el('div',{className:'title'},'능력(4개)'), ...rows, btnReroll);
-}
+      <button id="saveBtn" class="btn primary mt16">저장</button>
+    </div>
+  </section>
+  `;
 
-async function onReroll(){
-  if(creationLock) return;
-  lockCreation(true);
-  try{
-    const worldName = (App.state.worlds?.worlds||[]).find(w=>w.id===State.worldId)?.name || '';
-    const raw = await rerollSkills({ name: State.name, worldName, info: State.info });
-    const data = JSON.parse(raw);
-    if(Array.isArray(data.abilities) && data.abilities.length===4){
-      State.abilities = data.abilities.map(x=>({ name:x.name||'', desc_raw:x.desc_raw||x.desc||'', desc_soft:x.desc_soft||x.desc||'' }));
-      render();
-    } else { alert('리롤 실패: 형식 오류'); }
-  }catch(e){ alert(e.message||e); }
-  finally{ lockCreation(false); }
-}
-
-function narrativeBox(){
-  const iNar = el('textarea',{ placeholder:'서사(≤1000자, ≤20문장)', rows:6, value:State.narrative, oninput:(e)=>{ State.narrative=e.target.value; } });
-  const iSum = el('textarea',{ placeholder:'간단 소개(≤200자, ≤8문장)', rows:3, value:State.summary, oninput:(e)=>{ State.summary=e.target.value; } });
-  return el('div',{}, el('div',{className:'title'},'서사/소개'), iNar, iSum);
-}
-
-async function onGenerate(){
-  if(creationLock) return;
-  // 최소 입력 체크
-  if(!State.worldId || !State.name || !State.info) { alert('세계관/이름/정보를 입력해줘.'); return; }
-
-  lockCreation(true);
-  try{
-    // 1) 스케치(저가)
-    const world = App.state.worlds.worlds.find(w=>w.id===State.worldId);
-    const sites = world?.detail?.sites || [];
-    const participants = [{ name: State.name, desc_soft: State.abilities.map(a=>a.desc_soft).join(' / ') }];
-    const sketchText = await genSketch({ worldDetailSites: sites, participants });
-    let parsed; try{ parsed = JSON.parse(sketchText); }catch{ parsed = null; }
-    const pick = parsed?.options?.length ? parsed.options[Math.floor(Math.random()*parsed.options.length)] : null;
-    State.sketchPicked = pick;
-
-    // 2) 정제(고가)
-    const refinedText = await refineNarrative({ sketchOne: pick, worldIntro: world?.intro||'' });
-    let refined; try{ refined = JSON.parse(refinedText); }catch{ refined=null; }
-    if(refined){
-      State.narrative = refined.what || '';
-      State.summary   = (refined.where||'').slice(0,200);
-    }
-
-    // 3) 리롤이 비어있으면 1회 자동 제안
-    if(!State.abilities[0].name){
-      await onReroll();
-    }
-    renderReview();
-  }catch(e){ alert(e.message||e); }
-  finally{ lockCreation(false); }
-}
-
-function reviewCard(){
-  return el('div',{className:'card'},
-    el('div',{className:'title'}, '검토'),
-    el('div',{}, `세계관: ${State.worldId}`),
-    el('div',{}, `이름: ${State.name}`),
-    el('div',{}, `소개: ${State.summary||'(없음)'}`),
-    limitsRow()
-  );
-}
-
-function actionBar(){
-  const save = ()=>{
-    // 제한 확인
-    const ok = withinLimits({ name:State.name, info:State.info, narrative:State.narrative, summary:State.summary, abilities:State.abilities });
-    if(!ok){ alert('제한을 확인해줘.'); return; }
-
-    const id = 'char-'+Date.now();
-    const c = {
-      char_id:id, owner_uid: (App.user && App.user.uid) || 'anon',
-      world_id:State.worldId, name:State.name, input_info:State.info,
-      abilities: State.abilities.map(a=>({ name:a.name, desc:a.desc_soft, desc_raw:a.desc_raw })),
-      narrative: State.narrative, summary: State.summary,
-      likes_total:0, likes_weekly:0, elo:1200, wins:0, losses:0, draws:0,
-      createdAt: Date.now()
+  let world_id = worldList[0]?.id || 'gionkir';
+  const chips = root.querySelectorAll('#wchips .chip');
+  chips.forEach(b=>{
+    if(b.dataset.w === world_id) b.classList.add('active');
+    b.onclick = ()=>{
+      chips.forEach(x=>x.classList.remove('active'));
+      b.classList.add('active');
+      world_id = b.dataset.w;
     };
-    App.state.chars.push(c);
-    saveLocal();
-    // 서버 업서트(있으면)
-    if(typeof upsertCharToServer === 'function'){ upsertCharToServer(c).catch(()=>{}); }
-    alert('캐릭터 생성 완료!');
-    location.hash = `#/char/${id}`;
+  });
+
+  root.querySelector('#saveBtn').onclick = async ()=>{
+    const name = root.querySelector('#cname').value.trim();
+    const info = root.querySelector('#cinfo').value.trim();
+    if(!name) return showToast('이름을 입력해줘');
+    try{
+      const id = await createCharMinimal({ world_id, name, input_info: info });
+      location.hash = `#/char/${id}`;
+    }catch(e){ showToast('생성 실패: '+e.message); }
   };
-  const gen = el('button',{ className:'btn pri', disabled:creationLock, onclick:onGenerate }, 'AI 생성(저가→고가)');
-  const sv  = el('button',{ className:'btn', onclick:save }, '저장');
-  return el('div',{ className:'row', style:'gap:8px' }, gen, sv);
 }
-
-function renderForm(){
-  const v = document.getElementById('view');
-  v.replaceChildren(
-    el('div',{ className:'stack' },
-      el('div',{className:'title'},'새 캐릭터 만들기'),
-      worldChooser(),
-      baseInputs(),
-      abilitiesBox(),
-      narrativeBox(),
-      limitsRow(),
-      actionBar()
-    )
-  );
-}
-
-function renderReview(){
-  const v = document.getElementById('view');
-  v.replaceChildren(
-    el('div',{ className:'stack' },
-      el('div',{className:'title'},'생성 검토'),
-      reviewCard(),
-      abilitiesBox(),
-      narrativeBox(),
-      limitsRow(),
-      actionBar()
-    )
-  );
-}
-
-function render(){ renderForm(); }
-window.addEventListener('route', e=>{ if(e.detail.path==='create') render(); });
-render();

--- a/storage.rules
+++ b/storage.rules
@@ -1,9 +1,11 @@
+rules_version = '2';
 service firebase.storage {
-match /b/{bucket}/o {
-function isSignedIn() { return request.auth != null; }
-match /uploads/{uid}/{allPaths=**} {
-allow read: if true; // 썸네일/이미지 공개 가정
-allow write: if isSignedIn() && request.auth.uid == uid && request.resource.size < 10 * 1024 * 1024; // 10MB 제한
-}
-}
+  match /b/{bucket}/o {
+    match /char_avatars/{uid}/{charId}/{fileName=**} {
+      allow read: if true;
+      allow write: if request.auth != null && request.auth.uid == uid
+                   && request.resource.size < 2 * 1024 * 1024
+                   && request.resource.contentType.matches('image/.*');
+    }
+  }
 }


### PR DESCRIPTION
## Summary
- replace Firebase and store modules to support tiering, avatar uploads, and ability/item management
- add hash routes with new character creation and detailed character tabs
- style layout and update security rules for character and avatar data

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bab73c917883208459b21b100bc7e6